### PR TITLE
Remove 'True' from --privileged flag in unit file

### DIFF
--- a/templates/smokeping_prober.service.j2
+++ b/templates/smokeping_prober.service.j2
@@ -17,7 +17,9 @@ ExecStart=/usr/local/bin/smokeping_prober \
   --buckets={{ smokeping_prober_buckets }} \
 {% endif %}
   --ping.interval={{ smokeping_prober_ping_interval }} \
-  --privileged={{ smokeping_prober_privileged }} \
+{% if smokeping_prober_privileged is defined and smokeping_prober_privileged == True %}
+  --privileged \
+{% endif %}
   {% for host in smokeping_prober_hosts %}{{ host }} {% endfor %}
 
 SyslogIdentifier=smokeping_prober


### PR DESCRIPTION
Starting the smokeping_exporter with `--privileged=True` instead of
just `--privileged` will prevent it from starting with the error
`ERRO[0000] failed to create pinger: lookup True` as the exporter
seems to interpret the `True` as a host.

Fixes #12 