### PR TITLE
Remove PrivateUsers from unit file

### DIFF
--- a/templates/smokeping_prober.service.j2
+++ b/templates/smokeping_prober.service.j2
@@ -40,7 +40,6 @@ RemoveIPC=true
 RestrictSUIDSGID=true
 
 {% if smokeping_prober_systemd_version | int >= 232 %}
-PrivateUsers=true
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectKernelTunables=true


### PR DESCRIPTION
I'm no expert on the matter but through trial and error I found out that having the prober run with `PrivateUsers=true` seems to prevent it from receiving any new capabilities.

From the [man page](http://man7.org/linux/man-pages/man5/systemd.exec.5.html):

> PrivateUsers=
>     [...] If this mode is enabled, all unit
>     processes are run without privileges in the host user namespace
>     (regardless if the unit's own user/group is "root" or not).
>     Specifically this means that the process will have zero process
>     capabilities on the host's user namespace, but full capabilities
>     within the service's user namespace. **Settings such as
>     CapabilityBoundingSet= will affect only the latter, and there's
>     no way to acquire additional capabilities in the host's user
>     namespace.** Defaults to off.

Closes #14




